### PR TITLE
add error handling for window being too small

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
-use bevy::prelude::*;
+use bevy::{app::ScheduleRunnerPlugin, prelude::*};
+use std::time::Duration;
 
 mod net;
 mod tui;
@@ -20,7 +21,6 @@ fn main() {
                 },
             }),
             tui::TuiPlugin,
-            commands::CommandsPlugin,
         ))
         .run();
 

--- a/src/tui/draw.rs
+++ b/src/tui/draw.rs
@@ -1,5 +1,8 @@
 use super::{input::CommandInputState, Terminal};
-use bevy::prelude::*;
+use bevy::{
+    ecs::system::{Res, ResMut},
+    time::Time,
+};
 use ratatui::{
     layout::Rect,
     prelude::*,
@@ -24,67 +27,97 @@ pub fn render_system(
         .expect("Failed to draw terminal");
 }
 
-// TODO: Check if frame is too small a frame and complain if so
 fn render(frame: &mut Frame, input_state: &CommandInputState, cursor_visible: bool) {
     let frame_size = frame.size();
 
-    // Render Output section
-    frame.render_widget(
-        Block::new()
-            .borders(Borders::ALL)
-            .title(Title::from("Output/History").alignment(Alignment::Center)),
-        Rect::new(0, 0, frame_size.width, frame_size.height - 4),
-    );
-
-    // Render command input section
-    let input_block_rect = Rect::new(0, frame_size.height - 4, frame_size.width, 3);
-    frame.render_widget(
-        Paragraph::new(if cursor_visible {
-            if input_state.cursor_pos == input_state.content.chars().count() {
-                Line::from(vec![input_state.content.clone().into(), "_".into()])
-            } else {
-                Line::from(vec![
-                    input_state.content[..input_state.cursor_pos].into(),
-                    input_state
-                        .content
-                        .chars()
-                        .nth(input_state.cursor_pos)
-                        .unwrap()
-                        .to_string()
-                        .bg(Color::White)
-                        .fg(Color::Black),
-                    input_state.content[input_state.cursor_pos + 1..].into(),
-                ])
-            }
+    // complain if window is too small, width requirement is the lowest resolution that all the help text still dislpays at
+    if (frame_size.height < 10) | (frame_size.width < 120) {
+        if frame_size.width < 30 {
+            frame.render_widget(
+                Paragraph::new("window not large enough")
+                    .alignment(Alignment::Center)
+                    .style(Style::new().red()),
+                frame_size,
+            );
         } else {
-            Line::from(input_state.content.clone())
-        })
-        .block(Block::new().borders(Borders::ALL).title("Input Command")),
-        input_block_rect,
-    );
+            let text = vec![
+                Line::from(""),
+                Line::from("window must be atleast 120x10"),
+                Line::from(""),
+                Line::from(format!(
+                    "current size is {0} x {1}",
+                    frame_size.width, frame_size.height
+                )),
+            ];
+            frame.render_widget(
+                Paragraph::new(text)
+                    .alignment(Alignment::Center)
+                    .style(Style::new().red())
+                    .block(Block::new().borders(Borders::ALL).title(
+                        Title::from("window not large enough").alignment(Alignment::Center),
+                    )),
+                frame_size,
+            );
+        }
+    } else {
+        // Render Output section
+        frame.render_widget(
+            Block::new()
+                .borders(Borders::ALL)
+                .title(Title::from("Output/History").alignment(Alignment::Center)),
+            Rect::new(0, 0, frame_size.width, frame_size.height - 4),
+        );
 
-    // Render help text
-    frame.render_widget(
-        Paragraph::new(Line::from(vec![
-            "To escape, use the ".into(),
-            "exit".add_modifier(Modifier::UNDERLINED | Modifier::BOLD),
-            " command.".into(),
-        ]))
-        .alignment(Alignment::Left),
-        Rect::new(0, frame_size.height - 1, frame_size.width / 2, 1),
-    );
-    frame.render_widget(
-        Paragraph::new(Line::from(vec![
-            "For a list of commands and other aid, use the ".into(),
-            "help".add_modifier(Modifier::UNDERLINED | Modifier::BOLD),
-            " command.".into(),
-        ]))
-        .alignment(Alignment::Right),
-        Rect::new(
-            frame_size.width / 2,
-            frame_size.height - 1,
-            frame_size.width / 2,
-            1,
-        ),
-    );
+        // Render command input section
+        let input_block_rect = Rect::new(0, frame_size.height - 4, frame_size.width, 3);
+        frame.render_widget(
+            Paragraph::new(if cursor_visible {
+                if input_state.cursor_pos == input_state.content.chars().count() {
+                    Line::from(vec![input_state.content.clone().into(), "_".into()])
+                } else {
+                    Line::from(vec![
+                        input_state.content[..input_state.cursor_pos].into(),
+                        input_state
+                            .content
+                            .chars()
+                            .nth(input_state.cursor_pos)
+                            .unwrap()
+                            .to_string()
+                            .bg(Color::White)
+                            .fg(Color::Black),
+                        input_state.content[input_state.cursor_pos + 1..].into(),
+                    ])
+                }
+            } else {
+                Line::from(input_state.content.clone())
+            })
+            .block(Block::new().borders(Borders::ALL).title("Input Command")),
+            input_block_rect,
+        );
+
+        // Render help text
+        frame.render_widget(
+            Paragraph::new(Line::from(vec![
+                "To escape, use the ".into(),
+                "exit".add_modifier(Modifier::UNDERLINED | Modifier::BOLD),
+                " command.".into(),
+            ]))
+            .alignment(Alignment::Left),
+            Rect::new(0, frame_size.height - 1, frame_size.width / 2, 1),
+        );
+        frame.render_widget(
+            Paragraph::new(Line::from(vec![
+                "For a list of commands and other aid, use the ".into(),
+                "help".add_modifier(Modifier::UNDERLINED | Modifier::BOLD),
+                " command.".into(),
+            ]))
+            .alignment(Alignment::Right),
+            Rect::new(
+                frame_size.width / 2,
+                frame_size.height - 1,
+                frame_size.width / 2,
+                1,
+            ),
+        );
+    }
 }


### PR DESCRIPTION
added a screen to tell the user that their terminal window is too small, this also fixes a previous fatal error that occurred when resizing the window to very small sizes.

![image](https://github.com/CHATALOT1/orvin/assets/57061387/42a5beb8-0c12-44eb-8121-0a6d59ec4ab4)
